### PR TITLE
Remove final modifier from Prefser class

### DIFF
--- a/library/src/main/java/com/github/pwittchen/prefser/library/Prefser.java
+++ b/library/src/main/java/com/github/pwittchen/prefser/library/Prefser.java
@@ -54,7 +54,7 @@ import rx.functions.Func1;
  *      .subscribe(...);
  * </pre>
  */
-public final class Prefser {
+public class Prefser {
     private final SharedPreferences preferences;
     private final SharedPreferences.Editor editor;
     private final Map<Class, Accessor> accessors = new HashMap<>();


### PR DESCRIPTION
Hey! I love the library but I can't mock it! :disappointed: 

Removing the `final` modifier on the primary class will allow my team to use Mockito on this class.