### PR TITLE
Accept null value for put() to remove the key, fix NPE on null default value

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -4,6 +4,10 @@ android {
     compileSdkVersion 22
     buildToolsVersion "22.0.1"
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_7
+    }
+
     defaultConfig {
         minSdkVersion 9
         targetSdkVersion 22
@@ -36,9 +40,9 @@ dependencies {
     androidTestCompile('com.google.truth:truth:0.26') {
         exclude group: 'junit' // Android has JUnit built in.
     }
-    androidTestCompile 'com.google.dexmaker:dexmaker:1.0' // required by Mockito
-    androidTestCompile 'com.google.dexmaker:dexmaker-mockito:1.0' // required by Mockito
-    androidTestCompile 'org.mockito:mockito-core:1.9.5'
+    androidTestCompile 'com.google.dexmaker:dexmaker:1.2' // required by Mockito
+    androidTestCompile 'com.google.dexmaker:dexmaker-mockito:1.2' // required by Mockito
+    androidTestCompile 'org.mockito:mockito-core:1.10.19'
 }
 
 task wrapper(type: Wrapper) {

--- a/library/src/androidTest/java/com/github/pwittchen/prefser/library/PrefserTest.java
+++ b/library/src/androidTest/java/com/github/pwittchen/prefser/library/PrefserTest.java
@@ -210,6 +210,20 @@ public final class PrefserTest {
     }
 
     @Test
+    public void testRemoveByPuttingNull() throws Exception {
+        // given
+        String givenKey = "key1";
+        prefser.put(givenKey, 1);
+
+        // when
+        assertThat(prefser.contains(givenKey)).isTrue();
+        prefser.put(givenKey, null);
+
+        // then
+        assertThat(prefser.contains(givenKey)).isFalse();
+    }
+
+    @Test
     public void testRemoveShouldNotCauseErrorWhileRemovingKeyWhichDoesNotExist() {
         // given
         prefser.clear();
@@ -1038,19 +1052,6 @@ public final class PrefserTest {
         // given
         String key = null;
         String value = "someValue";
-
-        // when
-        prefser.put(key, value);
-
-        // then
-        // throw an exception
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testPutShouldThrowAnExceptionWhenValueIsNullForPut() {
-        // given
-        String key = "someKey";
-        String value = null;
 
         // when
         prefser.put(key, value);

--- a/library/src/androidTest/java/com/github/pwittchen/prefser/library/PrefserTest.java
+++ b/library/src/androidTest/java/com/github/pwittchen/prefser/library/PrefserTest.java
@@ -699,6 +699,19 @@ public final class PrefserTest {
     }
 
     @Test
+    public void testGetDefaultBooleanOfNull() {
+        // given
+        prefser.clear();
+        String keyWhichDoesNotExist = "keyWhichDoesNotExist";
+
+        // when
+        Boolean readValue = prefser.get(keyWhichDoesNotExist, Boolean.class, null);
+
+        // then
+        assertThat(readValue).isNull();
+    }
+
+    @Test
     public void testGetDefaultFloat() {
         // given
         prefser.clear();
@@ -1096,6 +1109,48 @@ public final class PrefserTest {
         // when
         RecordingObserver<Boolean> observer = new RecordingObserver<>();
         prefser.observe(givenKey, Boolean.class, defaultValue).subscribe(observer);
+        prefser.put(givenKey, givenValue);
+
+        // then
+        assertThat(observer.takeNext()).isTrue();
+        observer.assertNoMoreEvents();
+    }
+
+    @Test
+    public void testObserveBooleanBeingRemovedWithDefaultOfNull() {
+        // given
+        prefser.clear();
+        String givenKey = "someKey";
+        Boolean defaultValue = null;
+        prefser.put(givenKey, true);
+
+        // when
+        RecordingObserver<Boolean> observer = new RecordingObserver<>();
+        prefser.observe(givenKey, Boolean.class, defaultValue).subscribe(observer);
+        prefser.remove(givenKey);
+
+        // then
+        assertThat(observer.takeNext()).isNull();
+    }
+
+    @Test
+    public void testObserveBooleanBeingRemovedAndReput() {
+        // given
+        prefser.clear();
+        String givenKey = "someKey";
+        boolean givenValue = true;
+        Boolean defaultValue = false;
+        prefser.put(givenKey, true);
+
+        // when
+        RecordingObserver<Boolean> observer = new RecordingObserver<>();
+        prefser.observe(givenKey, Boolean.class, defaultValue).subscribe(observer);
+        prefser.remove(givenKey);
+
+        // then
+        assertThat(observer.takeNext()).isFalse();
+
+        // and when
         prefser.put(givenKey, givenValue);
 
         // then

--- a/library/src/main/java/com/github/pwittchen/prefser/library/Prefser.java
+++ b/library/src/main/java/com/github/pwittchen/prefser/library/Prefser.java
@@ -184,17 +184,17 @@ public class Prefser {
         checkNotNull(key, "key == null");
         checkNotNull(classOfT, "classOfT == null");
 
+        if (!contains(key)) {
+            return defaultValue;
+        }
+
         for (Map.Entry<Class, Accessor> entry : accessors.entrySet()) {
             if (classOfT.equals(entry.getKey())) {
                 return (entry.getValue()).get(key, classOfT, defaultValue);
             }
         }
 
-        if (contains(key)) {
-            return (T) jsonConverter.fromJson(preferences.getString(key, null), classOfT);
-        } else {
-            return defaultValue;
-        }
+        return (T) jsonConverter.fromJson(preferences.getString(key, null), classOfT);
     }
 
     /**

--- a/library/src/main/java/com/github/pwittchen/prefser/library/Prefser.java
+++ b/library/src/main/java/com/github/pwittchen/prefser/library/Prefser.java
@@ -245,11 +245,14 @@ public class Prefser {
      * Puts value to the SharedPreferences.
      *
      * @param key   key under which value will be stored
-     * @param value value to be stored
+     * @param value value to be stored, or null to remove the key
      */
     public void put(String key, Object value) {
         checkNotNull(key, "key == null");
-        checkNotNull(value, "value == null");
+        if (value == null) {
+            remove(key);
+            return;
+        }
 
         if (!accessors.containsKey(value.getClass())) {
             value = jsonConverter.toJson(value);


### PR DESCRIPTION
`sharedPreferences.putString(key, null)` removes that key.
This PR implements this in prefser.
Also fixes that null default value for primitive data types (`prefser.get(key, Integer.class, null)`) causes NPE.
Thanks!