### PR TITLE
now, get() method returns null when it's set as default value for key…

### DIFF
--- a/library/src/androidTest/java/com/github/pwittchen/prefser/library/PrefserTest.java
+++ b/library/src/androidTest/java/com/github/pwittchen/prefser/library/PrefserTest.java
@@ -2343,4 +2343,17 @@ public final class PrefserTest {
         assertThat(observer2.takeNext()).isEqualTo(givenKey);
         observer2.assertNoMoreEvents();
     }
+
+    @Test
+    public void testGetShouldReturnNullForStringType() {
+        // given
+        prefser.clear();
+        String keyWhichDoesNotExist = "keyWhichDoesNotExist";
+
+        // when
+        String value = prefser.get(keyWhichDoesNotExist, String.class, null);
+
+        // then
+        assertThat(value).isNull();
+    }
 }

--- a/library/src/main/java/com/github/pwittchen/prefser/library/Prefser.java
+++ b/library/src/main/java/com/github/pwittchen/prefser/library/Prefser.java
@@ -66,6 +66,7 @@ public class Prefser {
 
     private interface Accessor<T> {
         T get(String key, T defaultValue);
+
         void put(String key, T value);
     }
 
@@ -171,6 +172,7 @@ public class Prefser {
                     }
                 }));
     }
+
     /**
      * Gets value from SharedPreferences with a given key and type
      * as a RxJava Observable, which can be subscribed.
@@ -231,6 +233,10 @@ public class Prefser {
     public <T> T get(String key, Class<T> classOfT, T defaultValue) {
         checkNotNull(key, "key == null");
         checkNotNull(classOfT, "classOfT == null");
+
+        if (!contains(key) && defaultValue == null) {
+            return null;
+        }
 
         return get(key, TypeToken.fromClass(classOfT), defaultValue);
     }
@@ -324,8 +330,8 @@ public class Prefser {
     /**
      * Puts value to the SharedPreferences.
      *
-     * @param key   key under which value will be stored
-     * @param value value to be stored
+     * @param key          key under which value will be stored
+     * @param value        value to be stored
      * @param typeTokenOfT type token of T (e.g. {@code new TypeToken<> {})
      */
     public <T> void put(String key, T value, TypeToken<T> typeTokenOfT) {


### PR DESCRIPTION
… which does not exist for String type

Solves #70.