### PR TITLE
Feature/support null as default value (primitive types)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ ext.deps = [rxjava              : 'io.reactivex:rxjava:1.3.0',
             butterknifecompiler : 'com.jakewharton:butterknife-compiler:8.6.0',
             junit               : 'junit:junit:4.12',
             truth               : 'com.google.truth:truth:0.33',
-            robolectric         : 'org.robolectric:robolectric:3.1.2',
+            robolectric         : 'org.robolectric:robolectric:3.3.2',
             mockitocore         : 'org.mockito:mockito-core:2.8.47']
 
 buildscript {

--- a/library/src/main/java/com/github/pwittchen/prefser/library/Accessor.java
+++ b/library/src/main/java/com/github/pwittchen/prefser/library/Accessor.java
@@ -16,7 +16,7 @@
 package com.github.pwittchen.prefser.library;
 
 interface Accessor<T> {
-  T get(String key, T defaultValue);
+  T get(String key);
 
   void put(String key, T value);
 }

--- a/library/src/main/java/com/github/pwittchen/prefser/library/PreferencesAccessorsProvider.java
+++ b/library/src/main/java/com/github/pwittchen/prefser/library/PreferencesAccessorsProvider.java
@@ -48,7 +48,7 @@ class PreferencesAccessorsProvider implements AccessorsProvider {
   private void createBooleanAccessor() {
     accessors.put(Boolean.class, new Accessor<Boolean>() {
       @Override public Boolean get(String key, Boolean defaultValue) {
-        return preferences.getBoolean(key, defaultValue);
+        return preferences.getBoolean(key, (defaultValue == null) ? false : defaultValue);
       }
 
       @Override public void put(String key, Boolean value) {
@@ -60,7 +60,7 @@ class PreferencesAccessorsProvider implements AccessorsProvider {
   private void createFloatAccessor() {
     accessors.put(Float.class, new Accessor<Float>() {
       @Override public Float get(String key, Float defaultValue) {
-        return preferences.getFloat(key, defaultValue);
+        return preferences.getFloat(key, (defaultValue == null) ? 0f : defaultValue);
       }
 
       @Override public void put(String key, Float value) {
@@ -72,7 +72,7 @@ class PreferencesAccessorsProvider implements AccessorsProvider {
   private void createIntegerAccessor() {
     accessors.put(Integer.class, new Accessor<Integer>() {
       @Override public Integer get(String key, Integer defaultValue) {
-        return preferences.getInt(key, defaultValue);
+        return preferences.getInt(key, (defaultValue == null) ? 0 : defaultValue);
       }
 
       @Override public void put(String key, Integer value) {
@@ -84,7 +84,7 @@ class PreferencesAccessorsProvider implements AccessorsProvider {
   private void createLongAccessor() {
     accessors.put(Long.class, new Accessor<Long>() {
       @Override public Long get(String key, Long defaultValue) {
-        return preferences.getLong(key, defaultValue);
+        return preferences.getLong(key,  (defaultValue == null) ? 0L : defaultValue);
       }
 
       @Override public void put(String key, Long value) {

--- a/library/src/main/java/com/github/pwittchen/prefser/library/PreferencesAccessorsProvider.java
+++ b/library/src/main/java/com/github/pwittchen/prefser/library/PreferencesAccessorsProvider.java
@@ -47,8 +47,8 @@ class PreferencesAccessorsProvider implements AccessorsProvider {
 
   private void createBooleanAccessor() {
     accessors.put(Boolean.class, new Accessor<Boolean>() {
-      @Override public Boolean get(String key, Boolean defaultValue) {
-        return preferences.getBoolean(key, (defaultValue == null) ? false : defaultValue);
+      @Override public Boolean get(String key) {
+        return preferences.getBoolean(key, false);
       }
 
       @Override public void put(String key, Boolean value) {
@@ -59,8 +59,8 @@ class PreferencesAccessorsProvider implements AccessorsProvider {
 
   private void createFloatAccessor() {
     accessors.put(Float.class, new Accessor<Float>() {
-      @Override public Float get(String key, Float defaultValue) {
-        return preferences.getFloat(key, (defaultValue == null) ? 0f : defaultValue);
+      @Override public Float get(String key) {
+        return preferences.getFloat(key, 0f);
       }
 
       @Override public void put(String key, Float value) {
@@ -71,8 +71,8 @@ class PreferencesAccessorsProvider implements AccessorsProvider {
 
   private void createIntegerAccessor() {
     accessors.put(Integer.class, new Accessor<Integer>() {
-      @Override public Integer get(String key, Integer defaultValue) {
-        return preferences.getInt(key, (defaultValue == null) ? 0 : defaultValue);
+      @Override public Integer get(String key) {
+        return preferences.getInt(key, 0);
       }
 
       @Override public void put(String key, Integer value) {
@@ -83,8 +83,8 @@ class PreferencesAccessorsProvider implements AccessorsProvider {
 
   private void createLongAccessor() {
     accessors.put(Long.class, new Accessor<Long>() {
-      @Override public Long get(String key, Long defaultValue) {
-        return preferences.getLong(key,  (defaultValue == null) ? 0L : defaultValue);
+      @Override public Long get(String key) {
+        return preferences.getLong(key, 0L);
       }
 
       @Override public void put(String key, Long value) {
@@ -95,8 +95,8 @@ class PreferencesAccessorsProvider implements AccessorsProvider {
 
   private void createDoubleAccessor() {
     accessors.put(Double.class, new Accessor<Double>() {
-      @Override public Double get(String key, Double defaultValue) {
-        return Double.valueOf(preferences.getString(key, String.valueOf(defaultValue)));
+      @Override public Double get(String key) {
+        return Double.valueOf(preferences.getString(key, ""));
       }
 
       @Override public void put(String key, Double value) {
@@ -107,8 +107,8 @@ class PreferencesAccessorsProvider implements AccessorsProvider {
 
   private void createStringAccessor() {
     accessors.put(String.class, new Accessor<String>() {
-      @Override public String get(String key, String defaultValue) {
-        return preferences.getString(key, String.valueOf(defaultValue));
+      @Override public String get(String key) {
+        return preferences.getString(key, "");
       }
 
       @Override public void put(String key, String value) {

--- a/library/src/main/java/com/github/pwittchen/prefser/library/Prefser.java
+++ b/library/src/main/java/com/github/pwittchen/prefser/library/Prefser.java
@@ -232,8 +232,8 @@ public class Prefser {
     Preconditions.checkNotNull(key, KEY_IS_NULL);
     Preconditions.checkNotNull(classOfT, CLASS_OF_T_IS_NULL);
 
-    if (!contains(key) && defaultValue == null) {
-      return null;
+    if (!contains(key)) {
+      return defaultValue;
     }
 
     return get(key, TypeToken.fromClass(classOfT), defaultValue);

--- a/library/src/main/java/com/github/pwittchen/prefser/library/Prefser.java
+++ b/library/src/main/java/com/github/pwittchen/prefser/library/Prefser.java
@@ -229,13 +229,7 @@ public class Prefser {
    * @return value from SharedPreferences associated with given key or default value
    */
   public <T> T get(@NonNull String key, @NonNull Class<T> classOfT, T defaultValue) {
-    Preconditions.checkNotNull(key, KEY_IS_NULL);
     Preconditions.checkNotNull(classOfT, CLASS_OF_T_IS_NULL);
-
-    if (!contains(key)) {
-      return defaultValue;
-    }
-
     return get(key, TypeToken.fromClass(classOfT), defaultValue);
   }
 
@@ -253,20 +247,20 @@ public class Prefser {
     Preconditions.checkNotNull(key, KEY_IS_NULL);
     Preconditions.checkNotNull(typeTokenOfT, TYPE_TOKEN_OF_T_IS_NULL);
 
+    if (!contains(key)) {
+      return defaultValue;
+    }
+
     Type typeOfT = typeTokenOfT.getType();
 
     for (Map.Entry<Class<?>, Accessor<?>> entry : accessorProvider.getAccessors().entrySet()) {
       if (typeOfT.equals(entry.getKey())) {
         @SuppressWarnings("unchecked") Accessor<T> accessor = (Accessor<T>) entry.getValue();
-        return accessor.get(key, defaultValue);
+        return accessor.get(key);
       }
     }
 
-    if (contains(key)) {
-      return jsonConverter.fromJson(preferences.getString(key, null), typeOfT);
-    } else {
-      return defaultValue;
-    }
+    return jsonConverter.fromJson(preferences.getString(key, null), typeOfT);
   }
 
   /**

--- a/library/src/test/java/com/github/pwittchen/prefser/library/PrefserTest.java
+++ b/library/src/test/java/com/github/pwittchen/prefser/library/PrefserTest.java
@@ -1169,4 +1169,179 @@ public final class PrefserTest {
     // then
     assertThat(value).isNull();
   }
+
+  @Test public void testShouldReturnStringValueWithDefaultNull() {
+    // given
+    prefser.clear();
+    String key = GIVEN_KEY;
+    String givenValue = "someText";
+
+    // when
+    prefser.put(key, givenValue);
+    String readValue = prefser.get(key, String.class, null);
+
+    // then
+    assertThat(givenValue).isEqualTo(readValue);
+  }
+
+  // alteracoes comeca aqui
+
+  @Test public void testGetShouldReturnNullForCustomObject() {
+    // given
+    prefser.clear();
+    String keyWhichDoesNotExist = KEY_WHICH_DOES_NOT_EXIST;
+
+    // when
+    CustomClass value = prefser.get(keyWhichDoesNotExist, CustomClass.class, null);
+
+    // then
+    assertThat(value).isNull();
+//    CustomClass givenObject = new CustomClass(23, "someText");
+//    CustomClass defaultObject = new CustomClass(67, "defaultText");
+  }
+
+  @Test public void testGetShouldReturnCustomObjectWithDefaultNull() {
+    // given
+    prefser.clear();
+    String key = GIVEN_KEY;
+    CustomClass givenObject = new CustomClass(12, "someText");
+
+    // when
+    prefser.put(key, givenObject);
+    CustomClass readObject = prefser.get(key, CustomClass.class, null);
+
+    // then
+    assertThat(givenObject).isEqualTo(readObject);
+  }
+
+  @Test public void testShouldReturnNullForDoubleType() {
+    // given
+    prefser.clear();
+    String keyWhichDoesNotExist = KEY_WHICH_DOES_NOT_EXIST;
+
+    // when
+    Double value = prefser.get(keyWhichDoesNotExist, Double.class, null);
+
+    // then
+    assertThat(value).isNull();
+  }
+
+  @Test public void testShouldReturnDoubleValueWithDefaultNull() {
+    // given
+    prefser.clear();
+    String key = GIVEN_KEY;
+    Double givenValue = 7.77;
+
+    // when
+    prefser.put(key, givenValue);
+    Double readValue = prefser.get(key, Double.class, null);
+
+    // then
+    assertThat(givenValue).isEqualTo(readValue);
+  }
+
+  @Test public void testShouldReturnNullForBooleanType() {
+    // given
+    prefser.clear();
+    String keyWhichDoesNotExist = KEY_WHICH_DOES_NOT_EXIST;
+
+    // when
+    Boolean value = prefser.get(keyWhichDoesNotExist, Boolean.class, null);
+
+    // then
+    assertThat(value).isNull();
+  }
+
+  @Test public void testShouldReturnBooleanValueWithDefaultNull() {
+    // given
+    prefser.clear();
+    String key = GIVEN_KEY;
+    Boolean givenValue = true;
+
+    // when
+    prefser.put(key, givenValue);
+    Boolean readValue = prefser.get(key, Boolean.class, null);
+
+    // then
+    assertThat(givenValue).isEqualTo(readValue);
+  }
+
+  @Test public void testShouldReturnNullForIntegerType() {
+    // given
+    prefser.clear();
+    String keyWhichDoesNotExist = KEY_WHICH_DOES_NOT_EXIST;
+
+    // when
+    Integer value = prefser.get(keyWhichDoesNotExist, Integer.class, null);
+
+    // then
+    assertThat(value).isNull();
+  }
+
+  @Test public void testShouldReturnIntegerValueWithDefaultNull() {
+    // given
+    prefser.clear();
+    String key = GIVEN_KEY;
+    Integer givenValue = 7;
+
+    // when
+    prefser.put(key, givenValue);
+    Integer readValue = prefser.get(key, Integer.class, null);
+
+    // then
+    assertThat(givenValue).isEqualTo(readValue);
+  }
+
+  @Test public void testShouldReturnNullForFloatType() {
+    // given
+    prefser.clear();
+    String keyWhichDoesNotExist = KEY_WHICH_DOES_NOT_EXIST;
+
+    // when
+    Float value = prefser.get(keyWhichDoesNotExist, Float.class, null);
+
+    // then
+    assertThat(value).isNull();
+  }
+
+  @Test public void testShouldReturnFloatValueWithDefaultNull() {
+    // given
+    prefser.clear();
+    String key = GIVEN_KEY;
+    Float givenValue = 7.45f;
+
+    // when
+    prefser.put(key, givenValue);
+    Float readValue = prefser.get(key, Float.class, null);
+
+    // then
+    assertThat(givenValue).isEqualTo(readValue);
+  }
+
+  @Test public void testShouldReturnNullForLongType() {
+    // given
+    prefser.clear();
+    String keyWhichDoesNotExist = KEY_WHICH_DOES_NOT_EXIST;
+
+    // when
+    Long value = prefser.get(keyWhichDoesNotExist, Long.class, null);
+
+    // then
+    assertThat(value).isNull();
+  }
+
+  @Test public void testShouldReturnLongValueWithDefaultNull() {
+    // given
+    prefser.clear();
+    String key = GIVEN_KEY;
+    Long givenValue = 7L;
+
+    // when
+    prefser.put(key, givenValue);
+    Long readValue = prefser.get(key, Long.class, null);
+
+    // then
+    assertThat(givenValue).isEqualTo(readValue);
+  }
+
 }


### PR DESCRIPTION
Passing null as default value in `get` gives a `NullPointerException` when the key is already signed for primitive types. From my study of the code I see that it was passing the defValue (object of primitive) to SharedPreferences but it only accepts primitive types. This way sending a null gives the exception. I saw your comment in the #50 issue, but I think that sending null as default value make sense sometimes, even if using the primitive objects.
I also added some tests, you can run them in your version to see the problem by yourself.
You can see just the [first commit](https://github.com/LeonardooBorges/prefser/commit/2bb0108dfaf06f92e2285496f622a2c74e21a065) also, it already solves the issue, but the second one improves the readability and comprehension of the changes.
