### PR TITLE
Allow to pass custom instance of Gson object

### DIFF
--- a/library/src/main/java/com/github/pwittchen/prefser/library/rx2/GsonConverter.java
+++ b/library/src/main/java/com/github/pwittchen/prefser/library/rx2/GsonConverter.java
@@ -15,12 +15,21 @@
  */
 package com.github.pwittchen.prefser.library.rx2;
 
+import android.support.annotation.NonNull;
 import com.google.gson.Gson;
 import java.lang.reflect.Type;
 
 public final class GsonConverter implements JsonConverter {
 
-  private final Gson gson = new Gson();
+  private final Gson gson;
+
+  public GsonConverter(@NonNull Gson gson) {
+    this.gson = gson;
+  }
+
+  public GsonConverter() {
+    gson = new Gson();
+  }
 
   @Override public <T> T fromJson(String json, Type typeOfT) {
     return gson.fromJson(json, typeOfT);


### PR DESCRIPTION
Although the JsonConverter interface exists, in my use case I would only require to pass my GSON instance with my CustomAdapters set, so this constructor would greatly help this instead of having to create my own JsonConverter with exactly the same methods than the GsonConverter but with my custom GSON instance.